### PR TITLE
Dev shooter closed loop velocity control

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -50,14 +50,13 @@ public final class Constants {
     public static final int DRVTRN_SOL_RVS_CHN = 1;
 
     //Shooter Motor can id's
-    public static final int SHOOTER_MOTOR1 = 100;
-    public static final int SHOOTER_MOTOR2 = 200;
+    public static final int SHOOTER_MOTOR1 = 10;
 
     // Shooter motor PID constants for velocity control
-    public static final double SHOOTER_Kf = 0;
-    public static final double SHOOTER_Kp = 0;
+    public static final double SHOOTER_Kf = 0.051;
+    public static final double SHOOTER_Kp = 0.05;
     public static final double SHOOTER_Ki = 0;
-    public static final double SHOOTER_Kd = 0;
+    public static final double SHOOTER_Kd = 0.5;
     public static final int SHOOTER_PID_SLOT = 0;
     public static final int kTimeoutMs = 30;
     

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -53,6 +53,15 @@ public final class Constants {
     public static final int SHOOTER_MOTOR1 = 100;
     public static final int SHOOTER_MOTOR2 = 200;
 
+    // Shooter motor PID constants for velocity control
+    public static final double SHOOTER_Kf = 0;
+    public static final double SHOOTER_Kp = 0;
+    public static final double SHOOTER_Ki = 0;
+    public static final double SHOOTER_Kd = 0;
+    public static final int SHOOTER_PID_SLOT = 0;
+    public static final int kTimeoutMs = 30;
+    
+
     //Conveyor Motor can id's
     public static final int HORIZONTALCONVEYORMOTOR = 500;
     public static final int VERTICALCONVEYORMOTOR = 600;

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -14,6 +14,7 @@ import frc.robot.commands.DriveRobotOpenLoop;
 import frc.robot.commands.RunConveyorOpenLoop;
 import frc.robot.commands.RunIntakeMotor;
 import frc.robot.commands.RunShooterOpenLoop;
+import frc.robot.commands.SetShooterToSpeed;
 import frc.robot.commands.ShiftGear;
 import frc.robot.subsystems.ConveyorSubsystem;
 import frc.robot.subsystems.DifferentialDrivetrain;
@@ -68,7 +69,7 @@ public class RobotContainer {
     mc_aButton.whileHeld(new RunIntakeMotor(m_intakeSubsystem, -1 * Constants.DEFAULT_INTAKE_OUTPUT));
     dc_xButton.whenPressed(new DeployIntake(m_pneumaticSubsystem, m_intakeSubsystem));
     dc_yButton.whenPressed(new ShiftGear(m_pneumaticSubsystem, m_drivetrainSubsystem));
-    mc_rButton.whileHeld(new RunShooterOpenLoop(m_shooterSubsystem, 0.5));
+    mc_rButton.whileHeld(new SetShooterToSpeed(m_shooterSubsystem, 5000)); //Intake unit is RPM
     mc_lButton.whileHeld(new RunConveyorOpenLoop(m_conveyorSubsystem, 0.5));
   }
 

--- a/src/main/java/frc/robot/commands/SetShooterToSpeed.java
+++ b/src/main/java/frc/robot/commands/SetShooterToSpeed.java
@@ -1,0 +1,41 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.subsystems.ShooterSubsystem;
+
+public class SetShooterToSpeed extends CommandBase {
+  private final ShooterSubsystem m_shooterSubsystem;
+  private double m_speedRPM;
+  /** Creates a new SetShooterToSpeed. */
+  public SetShooterToSpeed(ShooterSubsystem shooterSubsystem, double speedRPM) {
+    m_shooterSubsystem = shooterSubsystem;
+    m_speedRPM = speedRPM;
+    addRequirements(m_shooterSubsystem);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {
+    m_shooterSubsystem.setShooterMotorSpeed(m_speedRPM);
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {}
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {
+    m_shooterSubsystem.setShooterMotorSpeed(0);
+  }
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return false;
+  }
+}

--- a/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
@@ -4,24 +4,70 @@
 
 package frc.robot.subsystems;
 
+import com.ctre.phoenix.motorcontrol.TalonFXControlMode;
+import com.ctre.phoenix.motorcontrol.TalonFXFeedbackDevice;
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonFX;
 
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
 
 public class ShooterSubsystem extends SubsystemBase {
   private final WPI_TalonFX m_shooterMotor1 = new WPI_TalonFX(Constants.SHOOTER_MOTOR1);
-  private final WPI_TalonFX m_shooterMotor2 = new WPI_TalonFX(Constants.SHOOTER_MOTOR2);
+  private final int encoderCountsPerRev = 2048;
+  
   /** Creates a new ShooterSubsystem. */
-  public ShooterSubsystem() {}
+  public ShooterSubsystem() {
+    configureMotorFeedback(m_shooterMotor1);
+  }
+
+  public void configureMotorFeedback(WPI_TalonFX motor){
+    m_shooterMotor1.configFactoryDefault();
+		
+		/* Config neutral deadband to be the smallest possible */
+		m_shooterMotor1.configNeutralDeadband(0.001);
+
+		/* Config sensor used for Primary PID [Velocity] */
+    m_shooterMotor1.configSelectedFeedbackSensor(TalonFXFeedbackDevice.IntegratedSensor,
+                                            Constants.SHOOTER_PID_SLOT, 
+											Constants.kTimeoutMs);
+											
+
+		/* Config the peak and nominal outputs */
+		m_shooterMotor1.configNominalOutputForward(0, Constants.kTimeoutMs);
+		m_shooterMotor1.configNominalOutputReverse(0, Constants.kTimeoutMs);
+		m_shooterMotor1.configPeakOutputForward(1, Constants.kTimeoutMs);
+		m_shooterMotor1.configPeakOutputReverse(-1, Constants.kTimeoutMs);
+
+		/* Config the Velocity closed loop gains in slot0 */
+		m_shooterMotor1.config_kF(Constants.SHOOTER_PID_SLOT, Constants.SHOOTER_Kf, Constants.kTimeoutMs);
+		m_shooterMotor1.config_kP(Constants.SHOOTER_PID_SLOT, Constants.SHOOTER_Kp, Constants.kTimeoutMs);
+		m_shooterMotor1.config_kI(Constants.SHOOTER_PID_SLOT, Constants.SHOOTER_Ki, Constants.kTimeoutMs);
+		m_shooterMotor1.config_kD(Constants.SHOOTER_PID_SLOT, Constants.SHOOTER_Kd, Constants.kTimeoutMs);
+		
+  }
+
+  public double getMotorSpeedRPM(WPI_TalonFX motorController){
+    double rawSpeed = motorController.getSelectedSensorVelocity(); // raw sensor units per 100ms
+    double motorSpeedRPM = rawSpeed / encoderCountsPerRev * 1000 * 60; // RPM, (sensor units / 100ms)(rev / sensor units)(ms / s) (s / min)
+    return motorSpeedRPM;
+  }
 
   @Override
   public void periodic() {
     // This method will be called once per scheduler run
+    SmartDashboard.putNumber("Shooter motor output: ", m_shooterMotor1.getMotorOutputPercent());
+    SmartDashboard.putNumber("Shooter motor speed (units per 100ms)", m_shooterMotor1.getSelectedSensorVelocity());
+    SmartDashboard.putNumber("Shooter speed (RPM)", getMotorSpeedRPM(m_shooterMotor1));
   }
 
   public void runShooterMotor(double inputCommand){
     m_shooterMotor1.set(inputCommand);
-    m_shooterMotor2.set(inputCommand);
+  }
+
+  public void setShooterMotorSpeed(double speedRPM){
+    double speed = speedRPM / (encoderCountsPerRev * 1000 * 60);
+    // Set in units per 100 ms
+    m_shooterMotor1.set(TalonFXControlMode.Velocity, speed);
   }
 }

--- a/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
@@ -66,7 +66,7 @@ public class ShooterSubsystem extends SubsystemBase {
   }
 
   public void setShooterMotorSpeed(double speedRPM){
-    double speed = speedRPM / (encoderCountsPerRev * 1000 * 60);
+    double speed = speedRPM * encoderCountsPerRev /  (1000 * 60);
     // Set in units per 100 ms
     m_shooterMotor1.set(TalonFXControlMode.Velocity, speed);
   }

--- a/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
@@ -4,8 +4,10 @@
 
 package frc.robot.subsystems;
 
+import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.TalonFXControlMode;
 import com.ctre.phoenix.motorcontrol.TalonFXFeedbackDevice;
+import com.ctre.phoenix.motorcontrol.TalonFXInvertType;
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonFX;
 
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
@@ -23,14 +25,14 @@ public class ShooterSubsystem extends SubsystemBase {
 
   public void configureMotorFeedback(WPI_TalonFX motor){
     m_shooterMotor1.configFactoryDefault();
-		
+		m_shooterMotor1.setNeutralMode(NeutralMode.Brake);
+    m_shooterMotor1.setInverted(TalonFXInvertType.Clockwise);
 		/* Config neutral deadband to be the smallest possible */
 		m_shooterMotor1.configNeutralDeadband(0.001);
 
 		/* Config sensor used for Primary PID [Velocity] */
     m_shooterMotor1.configSelectedFeedbackSensor(TalonFXFeedbackDevice.IntegratedSensor,
-                                            Constants.SHOOTER_PID_SLOT, 
-											Constants.kTimeoutMs);
+                                            Constants.SHOOTER_PID_SLOT, Constants.kTimeoutMs);
 											
 
 		/* Config the peak and nominal outputs */
@@ -65,9 +67,12 @@ public class ShooterSubsystem extends SubsystemBase {
     m_shooterMotor1.set(inputCommand);
   }
 
+  public double convertToNativeSpeedCountsPer100ms(double speedRPM){
+    return speedRPM * encoderCountsPerRev /  (1000 * 60) * 100;
+  }
+
   public void setShooterMotorSpeed(double speedRPM){
-    double speed = speedRPM * encoderCountsPerRev /  (1000 * 60);
     // Set in units per 100 ms
-    m_shooterMotor1.set(TalonFXControlMode.Velocity, speed);
+    m_shooterMotor1.set(TalonFXControlMode.Velocity, convertToNativeSpeedCountsPer100ms(speedRPM));
   }
 }


### PR DESCRIPTION
Alex,

Here is the code to run the shooter motor using the velocity control that we looked at today. Take note of a few things:
1. The gains we were calibrating with the pheonix tuner tool have been copied to `Constants`.
2. I added a new method to the `ShooterSubsystem` class to set the motor based on closed loop control, and added a method to `configureMotorFeedback` which sets the initialization for it (`SetShooterToSpeed.java`).
3. I created a simple command to set the shooter to a user defined speed, it is essentially the same as the open loop  version.
    - To test it, you'll need to pull my branch and check it out then deploy the code. Ex in git bash:
    ``` 
    git fetch origin
   ```
   - And then
   ```
    git checkout dev_shooter_closed_loop_velocity
    ```

4. When running the robot, opening Shuffleboard should add a few outputs on the shooter motor system as well. 

Something you can do without my direct help would be to try and refine the controller gains a bit more. You can read some more about it [here](https://docs.ctre-phoenix.com/en/stable/ch16_ClosedLoop.html#motion-magic-position-velocity-current-closed-loop-closed-loop), but I will do my best to summarize. Our strategy is essentially to make `Kf` try to get us as close to the output we want (or zero error) before using any `Kp`, `Ki`, or `Kd` terms. We are essentially using `Kf` (or a feedforward gain) to get us as close to our setpoint as we can, and then the PID feedback to perfect it. Here is what I would do:
1. Open the pheonix tuner tool and connect like we were doing. Remember my mistake and always press the "save" button after changing the gains :).
2. Set all gains except `Kf` to be zero.
3. We have a starting point for `Kf`, and we know we are usually going to run the motor to spin somewhere around 5,500 RPM. So we should tune `Kf` such that it gets our error as close to zero as we can. So start with what we have in the code, and modify it:
    - If the speed after trying to set to 5500 RPM (or 18773 units per 100 ms) is greater, reduce `Kf`, if it is less, increase `Kf`. 
    - Be as precise as you can here! I am sure we can improve on what we did today.
4. Once you have gotten the error as low as possible, starting using `Kp` to try and compensate. 
    - I'd start with what we have. Increase `Kp` until the response starts to oscillate. In the graph below, the purple line is "oscillating". This will be the actual motor speed oscillating around the setpoint.
- In our case we want to see something about like the red curve happen, but if it is something between the green and red one that is okay.
<img width="329" alt="Screen Shot 2022-01-29 at 8 14 22 PM" src="https://user-images.githubusercontent.com/41274566/151683035-fbd53969-b58c-4f28-9d1c-0d67358545d5.png">

5. Once you are here, set `Kd` to be 10x `Kp`.
6. Leave `Ki` at zero, we may use a small gain here, but probably do not need to.
7. Don't be too worried about "messing something up", you won't, so change and try at your will!

Once you have this looking even better than we have it, try setting some other setpoints and seeing how the error responds. 
- The max motor speed is 6,380 according to the [hardware documentation](https://store.ctr-electronics.com/content/user-manual/Falcon%20500%20User%20Guide.pdf).

### Important
- The setpoint you give it in pheonix tuner is in units of encoder counts per 100 ms, but you will think of it in RPM.
- To convert from RPM to encoder counts per 100 ms:`(speed in RPM) * 2048/1000/60*100`, or just `(speed in RPM) * 3.413`
- The command `SetShooterToSpeed` takes the speed in RPM, just like we would normally talk about.