### PR TITLE
Climber controls

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -64,6 +64,9 @@ public final class Constants {
     public static final int CLIMBER_MOTOR1 = 24;
     public static final int CLIMBER_MOTOR2 = 1000;
     public static final double DEFAULT_CLIMBER_OUTPUT = 0.5; 
+
+    // Climber limit switch
+    public static final int CLIMBER_LIMIT_SWITCH = 9;
     
     // Linear actuator
     public static final int LINEAR_ACTUATOR_1 = 0; // Unverified

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -11,10 +11,12 @@ import edu.wpi.first.wpilibj2.command.button.JoystickButton;
 import frc.robot.commands.BackupShootAuton;
 import frc.robot.commands.DeployIntake;
 import frc.robot.commands.DriveRobotOpenLoop;
+import frc.robot.commands.EndGameClimb;
 import frc.robot.commands.RunClimber1OpenLoop;
 import frc.robot.commands.RunHorizontalConveyor;
 import frc.robot.commands.RunIntakeMotor;
 import frc.robot.commands.RunVerticalConveyor;
+import frc.robot.commands.SetClimberToPosition;
 import frc.robot.commands.ShiftGear;
 import frc.robot.commands.ShootWithLTrigger;
 import frc.robot.subsystems.ClimberSubsystem;
@@ -67,6 +69,7 @@ public class RobotContainer {
     JoystickButton dc_aButton = new JoystickButton(m_driverController, XboxController.Button.kA.value);
     JoystickButton dc_bButton = new JoystickButton(m_driverController, XboxController.Button.kB.value);
     JoystickButton dc_yButton = new JoystickButton(m_driverController, XboxController.Button.kY.value);
+
     JoystickButton mc_aButton = new JoystickButton(m_manipulatorController, XboxController.Button.kA.value);
     JoystickButton mc_rButton = new JoystickButton(m_manipulatorController, XboxController.Button.kRightBumper.value);
     JoystickButton mc_lButton = new JoystickButton(m_manipulatorController, XboxController.Button.kLeftBumper.value);
@@ -76,8 +79,8 @@ public class RobotContainer {
 
     //Driver Controller
     dc_aButton.whenPressed(new ShiftGear(m_pneumaticSubsystem, m_drivetrainSubsystem));
-    dc_bButton.whileHeld(new RunClimber1OpenLoop(m_climberSubsystem, 0.2));
-    dc_yButton.whileHeld(new RunClimber1OpenLoop(m_climberSubsystem, -0.2));
+    dc_bButton.whileHeld(new SetClimberToPosition(m_climberSubsystem, "ready to climb position", 0.2));
+    dc_yButton.whileHeld(new EndGameClimb(m_climberSubsystem));
   
     //Munipulator Controller 
     mc_xButton.whileHeld(new RunHorizontalConveyor(m_hConveyorSubsystem, Constants.DEFAULT_HORIZONTAL_CONVEYOR_OUTPUT));

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -100,6 +100,7 @@ public class RobotContainer {
     mc_rButton.whileHeld(new RunVerticalConveyor(m_vConveyorSubsystem, Constants.DEFAULT_VERTICAL_CONVEYOR_OUTPUT));
     mc_xButton.whenPressed(new DeployIntake(m_pneumaticSubsystem, m_intakeSubsystem));
     mc_rButton.whenHeld(new RunIntakeMotor(m_intakeSubsystem,  -1 * Constants.DEFAULT_INTAKE_OUTPUT));
+    mc_lButton.whileHeld((new RunClimber1OpenLoop(m_climberSubsystem, 0.2)));
   }
 
   

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -88,8 +88,8 @@ public class RobotContainer {
 
     //Driver Controller
     dc_aButton.whenPressed(new ShiftGear(m_pneumaticSubsystem, m_drivetrainSubsystem));
-    dc_bButton.whileHeld(new SetClimberToPosition(m_climberSubsystem, "ready to climb position", 0.2));
-    dc_yButton.whileHeld(new EndGameClimb(m_climberSubsystem));
+    dc_bButton.whenPressed(new SetClimberToPosition(m_climberSubsystem, "ready to climb position", 0.2));
+    dc_yButton.whenPressed(new EndGameClimb(m_climberSubsystem));
   
     //Munipulator Controller 
     mc_yButton.whileHeld(new RunHorizontalConveyor(m_hConveyorSubsystem, Constants.DEFAULT_HORIZONTAL_CONVEYOR_OUTPUT)); //reversed

--- a/src/main/java/frc/robot/commands/EndGameClimb.java
+++ b/src/main/java/frc/robot/commands/EndGameClimb.java
@@ -1,0 +1,24 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
+import frc.robot.subsystems.ClimberSubsystem;
+
+// NOTE:  Consider using this command inline, rather than writing a subclass.  For more
+// information, see:
+// https://docs.wpilib.org/en/stable/docs/software/commandbased/convenience-features.html
+public class EndGameClimb extends SequentialCommandGroup {
+  /** Creates a new EndGameClimb. */
+  private final ClimberSubsystem m_climberSubsystem;
+  public EndGameClimb(ClimberSubsystem climberSubsystem) {
+    // Add your commands in the addCommands() call, e.g.
+    // addCommands(new FooCommand(), new BarCommand());
+    m_climberSubsystem = climberSubsystem;
+    addCommands(
+      new SetClimberToPosition(m_climberSubsystem, "end position", 0.4)
+    );
+  }
+}

--- a/src/main/java/frc/robot/commands/SetClimberToPosition.java
+++ b/src/main/java/frc/robot/commands/SetClimberToPosition.java
@@ -1,0 +1,47 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.subsystems.ClimberSubsystem;
+
+public class SetClimberToPosition extends CommandBase {
+  private final ClimberSubsystem m_climberSubsystem;
+  private String m_position;
+  private double m_output; 
+  /** Creates a new RaiseClimberToPosition. */
+  public SetClimberToPosition(ClimberSubsystem climberSubsystem, String position, double output) {
+    // Use addRequirements() here to declare subsystem dependencies.
+    m_climberSubsystem = climberSubsystem;
+    m_position = position;
+    m_output = output;
+    addRequirements(m_climberSubsystem);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {
+    if (m_climberSubsystem.getClimberState() != m_position){
+      m_climberSubsystem.setClimberMotor1Output(m_output);
+    }
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {
+    m_climberSubsystem.setClimberMotor1Output(0);
+  }
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return (m_climberSubsystem.getClimberState() == m_position) | (m_climberSubsystem.getClimberState() == "end position");
+  }
+}

--- a/src/main/java/frc/robot/subsystems/ClimberSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ClimberSubsystem.java
@@ -26,7 +26,6 @@ public class ClimberSubsystem extends SubsystemBase {
   private boolean climber1BrakeOn = false;
   private double maxServoExtention = 0.1; // meters
   private double distanceFromPivotPointMeters = 0.1; // Distance the servo is mounted from rotation point
-  private DigitalInput limitSwitch = new DigitalInput(Constants.CLIMBER_LIMIT_SWITCH); // Should be true at beginning
 
   /* 
     These are a constant offset to gravity. Set such that it retains a position of zero. This
@@ -104,17 +103,13 @@ public class ClimberSubsystem extends SubsystemBase {
     SmartDashboard.putNumber("Climber 1 position (meters)", convertCountsToPosition(currentPositionClimber1));
     SmartDashboard.putNumber("Climber 1 error", m_climberMotor1.getClosedLoopError());
     SmartDashboard.putNumber("Motor current", m_climberMotor1.getStatorCurrent());
-    SmartDashboard.putBoolean("Climber limit switch", getLimitSwitch());
+    SmartDashboard.putString("Climber state", getClimberState());
 
     // double currentPositionClimber2 = m_climberMotor1.getSelectedSensorPosition();
     // SmartDashboard.putNumber("Climber 2 counts", currentPositionClimber2);
     // SmartDashboard.putNumber("Climber 2 position (meters)", convertCountsToPosition(currentPositionClimber2));
     // SmartDashboard.putNumber("Climber 2 error", m_climberMotor2.getClosedLoopError());
 
-  }
-
-  public boolean getLimitSwitch(){
-    return limitSwitch.get();
   }
 
   public double getPositionMeters(){
@@ -185,11 +180,11 @@ public class ClimberSubsystem extends SubsystemBase {
     there is a small point below which we know that the limit switch must 
     be in the init position, or above which it must be extended.
     */
-    if (getLimitSwitch() & (getPositionMeters() < lowerThreshold)){
+    if  (getPositionMeters() < lowerThreshold){
       // Limit switch is active and position is not big, we must be at start spot
       return "init position";
     }
-    else if ((getLimitSwitch() & getPositionMeters() > upperThreshold)){
+    else if ( getPositionMeters() > upperThreshold){
       // Limit switch is active and position is big, we must be at end spot
       return "end position";
     }

--- a/src/main/java/frc/robot/subsystems/ClimberSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ClimberSubsystem.java
@@ -11,6 +11,7 @@ import com.ctre.phoenix.motorcontrol.TalonFXFeedbackDevice;
 import com.ctre.phoenix.motorcontrol.TalonFXInvertType;
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonFX;
 
+import edu.wpi.first.wpilibj.DigitalInput;
 import edu.wpi.first.wpilibj.Servo;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
@@ -24,6 +25,8 @@ public class ClimberSubsystem extends SubsystemBase {
   private boolean climber1BrakeOn = false;
   private double maxServoExtention = 0.1; // meters
   private double distanceFromPivotPointMeters = 0.1; // Distance the servo is mounted from rotation point
+  private DigitalInput limitSwitch = new DigitalInput(Constants.CLIMBER_LIMIT_SWITCH); // Should be true at beginning
+  private boolean climberExtended = false;
 
   /* 
     These are a constant offset to gravity. Set such that it retains a position of zero. This
@@ -97,12 +100,26 @@ public class ClimberSubsystem extends SubsystemBase {
     SmartDashboard.putNumber("Climber 1 counts", currentPositionClimber1);
     SmartDashboard.putNumber("Climber 1 position (meters)", convertCountsToPosition(currentPositionClimber1));
     SmartDashboard.putNumber("Climber 1 error", m_climberMotor1.getClosedLoopError());
+    SmartDashboard.putNumber("Motor current", m_climberMotor1.getStatorCurrent());
+    SmartDashboard.putBoolean("Climber limit switch", getLimitSwitch());
 
-    double currentPositionClimber2 = m_climberMotor1.getSelectedSensorPosition();
-    SmartDashboard.putNumber("Climber 2 counts", currentPositionClimber2);
-    SmartDashboard.putNumber("Climber 2 position (meters)", convertCountsToPosition(currentPositionClimber2));
-    SmartDashboard.putNumber("Climber 2 error", m_climberMotor2.getClosedLoopError());
+    // double currentPositionClimber2 = m_climberMotor1.getSelectedSensorPosition();
+    // SmartDashboard.putNumber("Climber 2 counts", currentPositionClimber2);
+    // SmartDashboard.putNumber("Climber 2 position (meters)", convertCountsToPosition(currentPositionClimber2));
+    // SmartDashboard.putNumber("Climber 2 error", m_climberMotor2.getClosedLoopError());
 
+  }
+
+  public boolean getLimitSwitch(){
+    return limitSwitch.get();
+  }
+
+  public void setExtendedFlag(boolean isDeployed){
+    climberExtended = isDeployed;
+  }
+
+  public double getPosition(){
+    return convertCountsToPosition(m_climberMotor1.getSelectedSensorPosition());
   }
 
   public double convertCountsToPosition(double positionCounts){

--- a/src/main/java/frc/robot/subsystems/ClimberSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ClimberSubsystem.java
@@ -26,7 +26,6 @@ public class ClimberSubsystem extends SubsystemBase {
   private double maxServoExtention = 0.1; // meters
   private double distanceFromPivotPointMeters = 0.1; // Distance the servo is mounted from rotation point
   private DigitalInput limitSwitch = new DigitalInput(Constants.CLIMBER_LIMIT_SWITCH); // Should be true at beginning
-  private boolean climberExtended = false;
 
   /* 
     These are a constant offset to gravity. Set such that it retains a position of zero. This
@@ -114,11 +113,7 @@ public class ClimberSubsystem extends SubsystemBase {
     return limitSwitch.get();
   }
 
-  public void setExtendedFlag(boolean isDeployed){
-    climberExtended = isDeployed;
-  }
-
-  public double getPosition(){
+  public double getPositionMeters(){
     return convertCountsToPosition(m_climberMotor1.getSelectedSensorPosition());
   }
 
@@ -168,4 +163,44 @@ public class ClimberSubsystem extends SubsystemBase {
   public void setClimberMotor1Output(double commandedOutput){
     m_climberMotor1.set(commandedOutput);
   }
+
+  public String getClimberState(){
+    /*
+    Adjust upperClimbWindowBound and lowerClimbWindowBound to be a range where the climber should stop 
+    during climbing. Instead of tuning a complicated control loop, we will call this
+    function to give us the current state of the climber, and use it to decide when 
+    to stop it when it has reached its peak height for climb.
+    */
+    double upperClimbWindowBound = 1.0;
+    double lowerClimbWindowBound = 0.95;
+    double lowerThreshold = 0.1; // below this, if the limit switch is on, robot will be "at init position"
+    double upperThreshold = 1.5; // Above this, if the limit switch is on, robot will be "at end position"
+
+    /*
+    Adjust the constants in the first two if/else if clauses so that
+    there is a small point below which we know that the limit switch must 
+    be in the init position, or above which it must be extended.
+    */
+    if (getLimitSwitch() & (getPositionMeters() < lowerThreshold)){
+      // Limit switch is active and position is not big, we must be at start spot
+      return "init position";
+    }
+    else if ((getLimitSwitch() & getPositionMeters() > upperThreshold)){
+      // Limit switch is active and position is big, we must be at end spot
+      return "end position";
+    }
+    else if ((getPositionMeters() < upperClimbWindowBound) & (getPositionMeters() > lowerClimbWindowBound)){
+      return "ready to climb position";
+    }
+    else if (getPositionMeters() < lowerClimbWindowBound){
+      return "Going up";
+    }
+    else if (getPositionMeters() > upperClimbWindowBound){
+      return "Going down";
+    }
+    else {
+      return "in between positions";
+    }
+  }
+
 }


### PR DESCRIPTION
The goal of this is to be simple code that does not require a controller to be tuned. This code is not ready yet, first a simple relationship between climber position and encoder counts is needed. This is a simple linear regression model created from the points measured on the robot. This is used in `ClimberSubsystem.convertCountsToPosition` to calculate how far the arm has extended, which is used to determine the state of the climber arm. Once this equation is added, a couple more things are needed:
0. Set the climber limit switch to DIO port 9.
    - Before trying any climbing, the value of the limit switch should be verified in Shuffleboard. The tile should be green for `true` when the climber is at the base and tripping the limit switch. If not, just invert the boolean in code.
2. Set the parameters in 174-177 of `ClimberSubsystem` appropriately (descriptions in the comments). Think of this as the climber arm continuously extends, then returns, but even as the position goes back down, the "position" measured by the code continues to increment in the positive direction.
    - Ideally, the `upperClimbWindowBound` and `lowerClimbWindowBound` create a small window during which the subsystem will stop when the climber is just above the bar. We don't want the window to be too small that it misses realizing it is in the window. The `lowerClimbeWindowBound` should be essentially just above the bar.
    - same concept for the thresholds, we want them to be as close as we can to 0 or to max height, but not so close such that we risk the robot blasting through the position during a 20ms scheduler call.
3. Adjust speed of motor on line 82 of `RobotContainer`. We want the arm to slowly go up so that it does not shoot through the target position before it can realize it has. 
4. Adjust the output in `EndGameClimb` so that it has enough juice to continue moving up, but not too fast.

@Oive-OiL @kinematicwolves
